### PR TITLE
Add `huey` and `walrus` to the list of Redis tools

### DIFF
--- a/tools.json
+++ b/tools.json
@@ -336,5 +336,19 @@
     "repository": "https://github.com/josiahcarlson/rom",
     "description": "Redis object mapper for Python using declarative models, with search over numeric, full text, prefix, and suffix indexes",
     "authors": ["josiahcarlson"]
+  },
+  {
+    "name": "huey",
+    "language": "Python",
+    "repository": "https://github.com/coleifer/huey",
+    "description": "Simple multi-threaded Python task queue. Supports Redis.",
+    "authors": ["coleifer"]
+  },
+    {
+    "name": "walrus",
+    "language": "Python",
+    "repository": "https://github.com/coleifer/walrus",
+    "description": "A collection of lightweight utilities for working with Redis in Python. Includes ORM, autocompletion, full-text search, cache, locks, and more.",
+    "authors": ["coleifer"]
   }
 ]


### PR DESCRIPTION
If you feel they would be appropriate, I'd like to propose adding two libraries to the list of Redis tools:
- [huey](https://github.com/coleifer/huey), a lightweight multi-threaded task queue that supports Redis. You can view the [documentation here](http://huey.readthedocs.org/en/latest/).
- [walrus](https://github.com/coleifer/walrus), a collection of utilities for working with Redis in Python. Includes an ORM, autocomplete, full-text search, caching, locking and more. You can view the [documentation here](http://walrus.readthedocs.org/en/latest/).

Thank you so much for creating Redis, it is a fantastic tool and an integral part of my workflow!
